### PR TITLE
Update URL for reachable server

### DIFF
--- a/Casks/mega.rb
+++ b/Casks/mega.rb
@@ -2,7 +2,7 @@ cask "mega" do
   version "7.0.26"
   sha256 "c736d74ab744e204a39be492c1bb08849e6fd406f8668cfb4393ddf47953aebc"
 
-  url "https://www.megasoftware.net/releases/MEGA#{version}_mac32_setup.dmg"
+  url "https://megasoftware.net/releases/MEGA#{version}_mac32_setup.dmg"
   name "MEGA"
   name "Molecular Evolutionary Genetics Analysis"
   homepage "https://megasoftware.net/"


### PR DESCRIPTION
*The current URL uses `www.` which is unreachable. I have confirmed the download file is reachable from the same path without subdomain prefix. I suspect MEGA Software has messed up their routing definitions.*

After making all changes to a cask, verify:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
